### PR TITLE
Extend Seal Server run docs for missing Intel SGX shared libs

### DIFF
--- a/scripts/dist-worker/README.md
+++ b/scripts/dist-worker/README.md
@@ -153,7 +153,13 @@ Workers need persistent keys that:
 - One `seal-server` instance can serve multiple workers
 - Without `seal-server`, workers will fail to initialize
 
-**For test mode:** `seal-server` is not required when using `--test --fake-ton` flags.
+**For test mode:**
+
+`seal-server` is not required when using `--test --fake-ton` flags.
+
+**Common Issues:**
+
+In case you miss required libraries (such as `libsgx_dcap_ql.so`), refer to [Intel SGX Installation Guide](https://cc-enabling.trustedservices.intel.com/intel-sgx-sw-installation-guide-linux/02/installation_instructions/) to get it for your distro.
 
 ## Monitoring
 


### PR DESCRIPTION
As mentioned in #14, when running the Seal Server, errors related to missing Intel SGX libraries might occur. Errors such as:
```
./bin/seal-server: error while loading shared libraries: libsgx_dcap_ql.so.1: cannot open shared object file: No such file or directory
```
or errors related to e.g. `libsgx-dcap-quote-verify`, `libtdx-attest-dev`, etc.

This PR updates the doc with common issues section to point to official docs from Intel. The docs describe hot to get shared libs for some of distros. 

As an example for Ubuntu 22 LTS it goes like below:
```
sudo tee /etc/apt/sources.list.d/intel-sgx.list > /dev/null <<EOF
deb [signed-by=/etc/apt/keyrings/intel-sgx-keyring.asc arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main
EOF
```

```
curl -fsSLO https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key
sudo mv intel-sgx-deb.key /etc/apt/keyrings/intel-sgx-keyring.asc
```

```
sudo apt update
sudo apt --yes install libsgx-dcap-ql libsgx-quote-ex libsgx-dcap-quote-verify libtdx-attest-dev sgx-aesm-service
```