### PR TITLE
feat(client): WebUI/Cline compatibility and configurable env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ libmicrohttpd-0.9.77-w32-bin.zip
 openssl-3.1.4.zip
 readline-5.0-1-lib.zip
 benchmark/server
+benchmark/hey
+nul
 mt-tools/data/
 mt-tools/.venv/
 mt-tools/uv.lock

--- a/benchmark/run-benchmark.sh
+++ b/benchmark/run-benchmark.sh
@@ -35,10 +35,19 @@ if command -v hey &> /dev/null; then
     HEY_CMD="hey"
 elif [ -f "$HOME/go/bin/hey" ]; then
     HEY_CMD="$HOME/go/bin/hey"
-else
+elif command -v go &> /dev/null; then
     echo "Installing hey..."
     go install github.com/rakyll/hey@latest
     HEY_CMD="$HOME/go/bin/hey"
+else
+    echo "Go not found. Downloading hey binary..."
+    HEY_DIR="$(cd "$(dirname "$0")" && pwd)"
+    HEY_BIN="$HEY_DIR/hey"
+    if [ ! -f "$HEY_BIN" ]; then
+        curl -sSL -o "$HEY_BIN" "https://storage.googleapis.com/hey-releases/hey_linux_amd64"
+        chmod +x "$HEY_BIN"
+    fi
+    HEY_CMD="$HEY_BIN"
 fi
 
 # Parse arguments

--- a/runners/client/ClientRunner.cpp
+++ b/runners/client/ClientRunner.cpp
@@ -93,7 +93,7 @@ void ClientRunner::run_get_models_request(
           jb.stop_object();
 
           auto res = jb.as_cslice().str();
-          http_send_static_answer(std::move(res), std::move(promise));
+          http_send_static_answer(std::move(res), std::move(promise), "application/json");
         });
   } else {
     auto request = cocoon::create_serialize_tl_object<cocoon_api::client_getWorkerTypesV2>();
@@ -134,7 +134,7 @@ void ClientRunner::run_get_models_request(
           jb.stop_object();
 
           auto res = jb.as_cslice().str();
-          http_send_static_answer(std::move(res), std::move(promise));
+          http_send_static_answer(std::move(res), std::move(promise), "application/json");
         });
   }
 }

--- a/scripts/cocoon-launch
+++ b/scripts/cocoon-launch
@@ -506,13 +506,15 @@ def run_client_local(cfg: Config):
 
     # Start router (SOCKS5 only, no reverse proxy) with colored output
     router = f'{cfg.build_dir}/tee/router'
-    router_proc = popen([router, '-S', '8116@tdx', '--serialize-info'],
+    router_policy = os.environ.get('COCOON_ROUTER_POLICY', 'tdx')
+    router_proc = popen([router, '-S', f'8116@{router_policy}', '--serialize-info'],
                        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1)
     router_thread = threading.Thread(target=stream_output, args=(router_proc, 'ROUTER', '36'), daemon=True)
     router_thread.start()
 
     # Run client with colored output
-    client_cmd = [f'{cfg.build_dir}/client-runner', '--config', f'{cfg.local_run_dir}/client-config.json', '-v3']
+    client_verbosity = os.environ.get('COCOON_CLIENT_VERBOSITY', '3')
+    client_cmd = [f'{cfg.build_dir}/client-runner', '--config', f'{cfg.local_run_dir}/client-config.json', f'-v{client_verbosity}']
     if cfg.fake_ton:
         client_cmd += ['--disable-ton', f'{cfg.local_run_dir}/fake-ton-config.json']
 
@@ -651,9 +653,11 @@ def ensure_build(build_dir: Path, targets: list[str]):
              '-S', str(script_dir),
              '-B', str(build_dir)], check=True)
 
-    # Build targets
-    print(f'Building {", ".join(targets)}...')
-    run(['cmake', '--build', str(build_dir), '-j', str(os.cpu_count() or 4),
+    # Build targets (set COCOON_BUILD_JOBS if you hit OOM e.g. on WSL)
+    jobs = os.environ.get('COCOON_BUILD_JOBS')
+    jobs = int(jobs) if jobs is not None else (os.cpu_count() or 4)
+    print(f'Building {", ".join(targets)}... (jobs={jobs})')
+    run(['cmake', '--build', str(build_dir), '-j', str(jobs),
          '--target'] + targets, check=True)
 
 


### PR DESCRIPTION
## Summary

Improves Cocoon client usability for OpenAI-compatible UIs (WebUI, Cline, etc.) and makes `cocoon-launch` configurable via environment variables without changing defaults.

## Changes

- **Client (`ClientRunner.cpp`)**  
  Set `Content-Type: application/json` for the models list response (`/v1/models`).  
  Some clients (e.g. WebUI, Cline) require this header to treat the response as JSON; without it they may fail or mis-handle the list.

- **cocoon-launch**  
  - `COCOON_ROUTER_POLICY` (default: `tdx`) — router listen policy (e.g. `any` for local/dev without TDX).  
  - `COCOON_CLIENT_VERBOSITY` (default: `3`) — client log level (`-vN`).  
  - `COCOON_BUILD_JOBS` — number of parallel build jobs (useful to limit memory use, e.g. on WSL).

- **benchmark**  
  `run-benchmark.sh` can run without Go: if `hey` is not in PATH and `go` is not installed, it downloads the `hey` binary so the benchmark still runs.

- **.gitignore**  
  Ignore `benchmark/hey` and `nul` (downloaded/generated artifacts).

## Backward compatibility

All new options use the same defaults as current behavior; no config or script changes required for existing users.

## Testing

- Client: verified models list returns `Content-Type: application/json` and is accepted by WebUI/Cline.
- cocoon-launch: default behavior unchanged; `COCOON_ROUTER_POLICY=any` and `COCOON_BUILD_JOBS` tested on WSL.
- Benchmark: runs with and without Go installed.